### PR TITLE
Enable deployment to Kubernetes

### DIFF
--- a/atomist-k8s-deployment.json
+++ b/atomist-k8s-deployment.json
@@ -1,0 +1,96 @@
+{
+  "apiVersion": "extensions/v1beta1",
+  "kind": "Deployment",
+  "metadata": {
+    "name": "horseguards",
+    "labels": {
+      "app": "horseguards",
+      "owner": "satellite-of-love",
+      "teamId": "T1JVCMVH7",
+      "creator": "atomist.k8-automation"
+    }
+  },
+  "spec": {
+    "replicas": 1,
+    "revisionHistoryLimit": 3,
+    "selector": {
+      "matchLabels": {
+        "app": "horseguards",
+        "owner": "satellite-of-love",
+        "teamId": "T1JVCMVH7"
+      }
+    },
+    "template": {
+      "metadata": {
+        "name": "horseguards",
+        "labels": {
+          "app": "horseguards",
+          "owner": "satellite-of-love",
+          "teamId": "T1JVCMVH7",
+          "creator": "atomist.k8-automation"
+        },
+        "annotations": {
+          "atomist.com/k8vent": "{\"environment\":\"testing\",\"webhooks\":[\"https://webhook.atomist.com/atomist/kube/teams/T1JVCMVH7\"]}",
+          "atomist.com/repo-image": "[{\"container\":\"horseguards\",\"repo\":{\"owner\":\"satellite-of-love\",\"name\":\"horseguards\"},\"image\":\"image_placeholder\"}]"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "name": "horseguards",
+            "image": "image_placeholder",
+            "imagePullPolicy": "IfNotPresent",
+            "resources": {
+              "limits": {
+                "cpu": "300m",
+                "memory": "384Mi"
+              },
+              "requests": {
+                "cpu": "100m",
+                "memory": "320Mi"
+              }
+            },
+            "readinessProbe": {
+              "httpGet": {
+                "path": "/info",
+                "port": "http",
+                "scheme": "HTTP"
+              },
+              "initialDelaySeconds": 60,
+              "timeoutSeconds": 3,
+              "periodSeconds": 10,
+              "successThreshold": 1,
+              "failureThreshold": 3
+            },
+            "livenessProbe": {
+              "httpGet": {
+                "path": "/health",
+                "port": "http",
+                "scheme": "HTTP"
+              },
+              "initialDelaySeconds": 60,
+              "timeoutSeconds": 3,
+              "periodSeconds": 10,
+              "successThreshold": 1,
+              "failureThreshold": 3
+            },
+            "ports": [
+              {
+                "name": "http",
+                "containerPort": 8080,
+                "protocol": "TCP"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "strategy": {
+      "type": "RollingUpdate",
+      "rollingUpdate": {
+        "maxUnavailable": 0,
+        "maxSurge": 1
+      }
+    }
+  }
+}


### PR DESCRIPTION
This will trigger the Software Development Machine to request deployment of this service in a Kubernetes environment.

The Atomist playground kubernetes environment is restricted, so changes to this file will not change anything there.
In your own kubernetes environment, you can do what you like; see https://github.com/atomist/k8-automation for a starting point.